### PR TITLE
[proposal] move callback from `new` to `tick`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,10 @@
 use cmake;
 
 fn main() {
+    println!("cargo::rerun-if-changed=DRAMsim3");
+
     let dst = cmake::build("DRAMsim3");
-    println!("cargo:rustc-link-search=native={}/lib", dst.display());
-    println!("cargo:rustc-link-lib=dylib=stdc++");
-    println!("cargo:rustc-link-lib=static=dramsim3");
+    println!("cargo::rustc-link-search=native={}/lib", dst.display());
+    println!("cargo::rustc-link-lib=static=dramsim3");
+    println!("cargo::rustc-link-lib=dylib=stdc++");
 }


### PR DESCRIPTION
This PR proposes a **breaking change** to public API.

Before:

```Rust
impl MemorySystem {
    fn new(..., cb: impl FnMut(u64, bool) + 'static) -> Self { ... }
    fn tick(&mut self) { ... }
}
```

After:
```Rust
impl MemorySystem {
    fn new(...) -> Self { ... }
    fn tick(&mut self, cb: impl FnMut(u64, bool)) { ... }
}
```

 I believe the API plays more well with Rust's ownership and lifetime rules.

`RawCallbackFnMut` is annotated as `#[repr(C)]`, thus we could move `_invoke_cb` to C side to reduce one indirection. I don't do it in this PR because modifying C code is hard.

This PR has two independent commits. The first one is the proposal. The second one cleans up `build.rs`:
- Add `cargo::rerun-if-changed`
- Use `cargo::` instead of `cargo:` introduced from cargo 1.77
- Tweak lib order to avoid undefined symbol error in linking
